### PR TITLE
Linking to our assembly directly

### DIFF
--- a/main.json
+++ b/main.json
@@ -732,7 +732,7 @@
                 {
                  "name":"openWebsite",
                  "type":"string",
-                 "value":"https:\/\/spielevereinweltenwanderer.de\/"
+                 "value":"https:\/\/rc3.world\/rc3\/assembly\/spielekiste\/"
                 }],
          "type":"tilelayer",
          "visible":true,
@@ -887,7 +887,7 @@
  "nextobjectid":2,
  "orientation":"orthogonal",
  "renderorder":"right-down",
- "tiledversion":"2020.11.25",
+ "tiledversion":"1.4.3",
  "tileheight":32,
  "tilesets":[
         {


### PR DESCRIPTION
I would like to link to our assambly instead of to the weltenwanderer website directly. The scheduled events are on the assembly page.